### PR TITLE
Adding globalData to ContentZone and Types interfaces

### DIFF
--- a/src/ContentZone.tsx
+++ b/src/ContentZone.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { ContentZoneProps } from './types';
 
 
-export const ContentZone:FC<ContentZoneProps> = ({ name, page, sitemapNode, dynamicPageItem, languageCode, channelName, getModule, isDevelopmentMode, isPreview }) => {
+export const ContentZone:FC<ContentZoneProps> = ({ name, page, sitemapNode, dynamicPageItem, languageCode, channelName, getModule, isDevelopmentMode, isPreview, globalData }) => {
 
 	const RenderModules = () => {
 		if (!page) return null
@@ -22,7 +22,8 @@ export const ContentZone:FC<ContentZoneProps> = ({ name, page, sitemapNode, dyna
 				 channelName,
 				 customData: m.customData || null,
 				 isDevelopmentMode,
-				 isPreview
+				 isPreview,
+				 globalData: globalData
 
 			}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,13 +41,13 @@ export interface AgilityPageProps {
   page?: any;
   dynamicPageItem?: any;
   pageTemplateName?: string | null;
-  globalData?: { [name: string]: any };
   languageCode?: string | null;
   channelName?: string | null;
   isPreview?: boolean;
   isDevelopmentMode?: boolean;
   notFound?: boolean;
   getModule?(moduleName: string): ModuleWithInit | null;
+  globalData?: { [name: string]: any };
 }
 
 export interface CustomInitPropsArg {
@@ -78,6 +78,7 @@ export interface ModuleProps<T> {
   dynamicPageItem?: ContentItem<any>;
   isDevelopmentMode: boolean;
   isPreview: boolean;
+  globalData?: { [name: string]: any };
 }
 
 export interface DynamicModuleProps<T, D> {
@@ -87,6 +88,7 @@ export interface DynamicModuleProps<T, D> {
   channelName: string;
   sitemapNode: any;
   dynamicPageItem?: ContentItem<D>;
+  globalData?: { [name: string]: any };
 }
 
 export interface CustomInitProps<T, C> extends ModuleProps<T> {
@@ -137,6 +139,7 @@ export interface ContentZoneProps {
   getModule(moduleName: string): ModuleWithInit | null;
   isDevelopmentMode: boolean;
   isPreview: boolean;
+  globalData?: { [name: string]: any };
 }
 
 export interface Properties {


### PR DESCRIPTION
Two modifications have been made to the original code; 

1. ContentZone.tsx now destructures globalData and adds it to the props object passed to the Agility Module component
2. globalData was added to the Types interfaces for ModuleProps, DynamicModuleProps and ContentZoneProps so that globalData can continue to be prop drilled down into the modules. 

**Purpose of PR**
To allow global data to be pulled in at build time via GetStaticProps in [...slug].tsx in the root of your pages folder and passed into modules.